### PR TITLE
fix(ops): load registrar.cljs after ten-x-adapter.cljs

### DIFF
--- a/scripts/ops.clj
+++ b/scripts/ops.clj
@@ -227,13 +227,14 @@
    come first so their nses exist when the facade's :require fires at
    REPL time."
   ["console.cljs"
-   "registrar.cljs"
    "re_com.cljs"
    "session.cljs"
    "versions.cljs"
    ;; ten-x-adapter depends on re-com (classify-render-entry); load
    ;; after the re-com submodule.
    "ten_x_adapter.cljs"
+   ;; registrar depends on ten-x-adapter; load after it.
+   "registrar.cljs"
    ;; native-epoch depends on ten-x-adapter (aget-path, coerce-epoch).
    "native_epoch.cljs"
    ;; dispatch depends on console (current-who, append-console-entry!),


### PR DESCRIPTION
## Summary

- `runtime-submodule-files` in `scripts/ops.clj` had `registrar.cljs` in slot #2 and `ten_x_adapter.cljs` in slot #6.
- `registrar.cljs:5` `:require`s `re-frame-pair.runtime.ten-x-adapter`.
- On cold inject this trips `:tag :shadow.build.resolve/missing-ns` during the chunked source-ship, aborting the inject and leaving the runtime ns absent. Every subsequent op returns nil.
- Reorder: move `registrar.cljs` to immediately after `ten_x_adapter.cljs`, with a comment naming the dependency.

## Test plan

- [x] Reproduced against a live host project (re-frame 1.4.7, re-frame-10x 1.12.0, shadow-cljs 2.20.11): `discover-app.sh` returned `nil`; watch.log showed `:shadow.build.resolve/missing-ns` for `registrar.cljs` requiring `ten-x-adapter`.
- [x] Post-fix: `discover-app.sh` returns full health data; `app-summary.sh` returns the full registry/subs/app-db summary.
- [ ] Topology test (assert load order is valid wrt actual `:require`s) — happy to add as a follow-up if maintainers want.

## Notes

- Existing comments in the load-order list document ten-x-adapter / native-epoch / dispatch deps, but missed registrar's dep on ten-x-adapter — likely how this slipped in. Added a comment at the new position.
- Separate (less critical) issue noticed during testing: `eval-cljs.sh` returns `:value nil` even for trivial forms (e.g. `(+ 1 2)`) after a successful inject. Dedicated shims (`app-summary`, `dispatch`, etc.) work fine, so the blast radius is limited to the raw escape-hatch op. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)